### PR TITLE
Quando o usuário não possui nenhuma imagem como avatar o servidor quebra

### DIFF
--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -14,7 +14,7 @@ userRouter.get('/', async (req, res) => {
     type,
     display_name,
     email,
-    avatar: images[0].url,
+    avatar: images.length ? images[0].url : '',
   };
 
   return res.json(user);


### PR DESCRIPTION
No caso de usuário que não possui imagem de perfil, o meu usuário por exemplo, com isso adicionei uma validação na rota de usuários no arquivo **src/routes/user.routes.ts na linha 17**

`avatar: images.length ? images[0].url : '',`

Nesse caso a resposta da api do Spotify tem o seguinte formato:

```
{
  country: 'BR',
  display_name: 'display_name',
  email: 'email@user.com',
  explicit_content: { filter_enabled: false, filter_locked: false },
  external_urls: { spotify: 'https://open.spotify.com/user/username' },
  followers: { href: null, total: 0 },
  href: 'https://api.spotify.com/v1/users/mateus_paixao',
  id: 'username',
  images: [],
  product: 'premium',
  type: 'user',
  uri: 'spotify:user:username'
}
```
Portando o seguinte erro foi corrigido:

![Capture](https://user-images.githubusercontent.com/20425031/86525233-ebc34b00-be5a-11ea-86ad-56fbc301da0d.JPG)

Parabéns pelo excelente trabalho, o app está incrível! Forte abraço 🎉🎉🎉
